### PR TITLE
lock react-native-side-menu version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "./node_modules/.bin/react-native-webpack-server start"
   },
   "dependencies": {
-    "react-native-side-menu": "^0.9.2"
+    "react-native-side-menu": "0.9.2"
   },
   "devDependencies": {
     "babel": "^5.6.7",


### PR DESCRIPTION
react-native-side-menu >=0.9.3 will ask for react-native >=0.7, while rn 0.7.x has a [conflict](https://github.com/mjohnston/react-native-webpack-server/issues/40) with webpack