### PR TITLE
add NSAppTransportSecurity for xcode 7 & iOS 9

### DIFF
--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -45,5 +45,10 @@
 	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
add NSAppTransportSecurity for xcode 7 & iOS 9, otherwise the js files would be blocked.