### PR TITLE
seems "===" always returns false

### DIFF
--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -35,7 +35,8 @@ export default class State extends EventEmitter {
   }
 
   set(state, path?) {
-    if (this._state === state) return;
+    //if (this._state === state) return;
+    if(immutable.is(this._state, state)) return;
     // Previous state if useful for debugging global app state diff.
     // It's easy with: https://github.com/intelie/immutable-js-diff
     const previousState = this._state;


### PR DESCRIPTION
I am not so familiar with immutablejs. But to my observation, "===" always returns false when state is a complex nested structure with completely same value. Shouldn't [immutable.is()](http://facebook.github.io/immutable-js/docs/#/is) be used here? Please correct me if I am wrong. Thx!